### PR TITLE
🔒 Fix insecure HTTP usage in ScraperAPI calls

### DIFF
--- a/Antigravity/fetchAG.ps1
+++ b/Antigravity/fetchAG.ps1
@@ -9,7 +9,7 @@ if (-not $ApiKey) {
 
 # Build the ScraperAPI URL
 $TargetUrl = "https://antigravity.google/download"
-$ScraperUrl = "http://api.scraperapi.com?api_key=$ApiKey&url=$TargetUrl&render=true&wait_for=5000"
+$ScraperUrl = "https://api.scraperapi.com?api_key=$ApiKey&url=$TargetUrl&render=true&wait_for=5000"
 
 Write-Host "Fetching URL: $ScraperUrl"
 

--- a/Antigravity/fetchAG.sh
+++ b/Antigravity/fetchAG.sh
@@ -7,7 +7,7 @@ API_KEY="${SCRAPERAPI_KEY:-your_scraperapi_key_here}"
 TARGET_URL="https://antigravity.google/download"
 # Enable JavaScript rendering with render=true
 # Add wait_for=5000 to wait 5 seconds for JS to execute (in milliseconds)
-SCRAPER_URL="http://api.scraperapi.com?api_key=${API_KEY}&url=${TARGET_URL}&render=true&wait_for=5000"
+SCRAPER_URL="https://api.scraperapi.com?api_key=${API_KEY}&url=${TARGET_URL}&render=true&wait_for=5000"
 
 echo "Fetching URL: ${SCRAPER_URL}"
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Changed ScraperAPI endpoint URLs from `http://` to `https://` in `Antigravity/fetchAG.ps1` and `Antigravity/fetchAG.sh`.

⚠️ **Risk:** The potential impact if left unfixed
The previous implementation was sending API keys (`$ApiKey`/`${API_KEY}`) as URL query parameters over an unencrypted connection (HTTP). An attacker able to monitor network traffic could easily intercept the plaintext API key, which could lead to unauthorized usage of the ScraperAPI service, potentially incurring costs or allowing malicious actions associated with the compromised account.

🛡️ **Solution:** How the fix addresses the vulnerability
Updated the ScraperAPI URL to use HTTPS (`https://api.scraperapi.com`), which encrypts the connection between the client and the API server, ensuring the API key is not transmitted in plaintext.

---
*PR created automatically by Jules for task [3180157210176060559](https://jules.google.com/task/3180157210176060559) started by @targed*