### PR TITLE
🔒 Fix potential DoS/Memory Leak by adding UseBasicParsing to Invoke-WebRequest

### DIFF
--- a/Chocolatey-Package-Updater.ps1
+++ b/Chocolatey-Package-Updater.ps1
@@ -699,7 +699,7 @@ function UpdateChocolateyPackage {
         }
         else {
             Write-Debug "Using Invoke-WebRequest to download the file."
-            Invoke-WebRequest -Uri $url -OutFile $tempPath
+            Invoke-WebRequest -Uri $url -OutFile $tempPath -UseBasicParsing
         }
 
         # Verify the file exists
@@ -828,7 +828,7 @@ function UpdateChocolateyPackage {
             Write-Debug "Scraping URL: $ScrapeUrl"
             Write-Debug "Scrape pattern: $ScrapePattern"
 
-            $page = Invoke-WebRequest -Uri $ScrapeUrl
+            $page = Invoke-WebRequest -Uri $ScrapeUrl -UseBasicParsing
             if ($page.Content -match $ScrapePattern -and $matches[0] -match '^\d+(\.\d+){1,3}$') {
                 Write-Output "Scraped version: $($matches[0])"
                 $ForceVersionNumber = $matches[0]
@@ -843,7 +843,7 @@ function UpdateChocolateyPackage {
             Write-Debug "Scraping URL: $ScrapeUrl"
             Write-Debug "Download URL scrape pattern: $DownloadUrlScrapePattern"
 
-            $page = Invoke-WebRequest -Uri $ScrapeUrl
+            $page = Invoke-WebRequest -Uri $ScrapeUrl -UseBasicParsing
             if ($page.Content -match $DownloadUrlScrapePattern) {
                 Write-Output "Scraped download URL: $($matches[0])"
                 $FileUrl = $matches[0]
@@ -857,7 +857,7 @@ function UpdateChocolateyPackage {
                 Write-Debug "Scraping URL: $ScrapeUrl"
                 Write-Debug "Download URL scrape pattern (64-bit): $DownloadUrlScrapePattern"
 
-                $page = Invoke-WebRequest -Uri $ScrapeUrl
+                $page = Invoke-WebRequest -Uri $ScrapeUrl -UseBasicParsing
                 if ($page.Content -match $DownloadUrlScrapePattern64) {
                     Write-Output "Scraped 64-bit download URL: $($matches[0])"
                     $FileUrl64 = $matches[0]

--- a/CloudCompare/updateNew.ps1
+++ b/CloudCompare/updateNew.ps1
@@ -36,7 +36,7 @@ while ($continueSearching -and $majorVersion -lt 10) {
     $mostUpToDateUrl = "https://www.cloudcompare.org/release/CloudCompare_v${versionNumber}_setup_x64.exe"
     
     try {
-        $response = Invoke-WebRequest -Uri $mostUpToDateUrl -Method Head -ErrorAction Stop
+        $response = Invoke-WebRequest -Uri $mostUpToDateUrl -UseBasicParsing -Method Head -ErrorAction Stop
         Write-Host "$mostUpToDateUrl is valid and reachable (Status Code: $($response.StatusCode))."
         
         $lastWorkingVersion = $versionNumber

--- a/Comet/updateNew.ps1
+++ b/Comet/updateNew.ps1
@@ -5,7 +5,7 @@ $ParentPath = Split-Path -Parent $ScriptPath
 # Import the UpdateChocolateyPackage function
 . (Join-Path $ParentPath 'Chocolatey-Package-Updater.ps1')
 
-# $downloadPage = Invoke-WebRequest -Uri "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=win_x64&mini=1" | ConvertFrom-Json
+# $downloadPage = Invoke-WebRequest -Uri "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=win_x64&mini=1" -UseBasicParsing | ConvertFrom-Json
 # $jsonObject = ($downloadPage.downloadUrl)
 
 # Create a hash table to store package information

--- a/Cursor/updateNew.ps1
+++ b/Cursor/updateNew.ps1
@@ -6,11 +6,11 @@ $ParentPath = Split-Path -Parent $ScriptPath
 . (Join-Path $ParentPath 'Chocolatey-Package-Updater.ps1')
 
 # Get User Installer URL
-$downloadPageUser = Invoke-WebRequest -Uri "https://www.cursor.com/api/download?platform=win32-x64-user&releaseTrack=stable" | ConvertFrom-Json
+$downloadPageUser = Invoke-WebRequest -Uri "https://www.cursor.com/api/download?platform=win32-x64-user&releaseTrack=stable" -UseBasicParsing | ConvertFrom-Json
 $urlUser = ($downloadPageUser.downloadUrl)
 
 # Get System Installer URL
-$downloadPageSystem = Invoke-WebRequest -Uri "https://cursor.com/api/download?platform=win32-x64&releaseTrack=stable" | ConvertFrom-Json
+$downloadPageSystem = Invoke-WebRequest -Uri "https://cursor.com/api/download?platform=win32-x64&releaseTrack=stable" -UseBasicParsing | ConvertFrom-Json
 $urlSystem = ($downloadPageSystem.downloadUrl)
 
 # Create a hash table to store package information

--- a/EXAMPLES/updateNew.ps1
+++ b/EXAMPLES/updateNew.ps1
@@ -7,7 +7,7 @@ $ScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $ParentPath = Split-Path -Parent $ScriptPath
 
 # How to get the version and download URL from JSON endpoint
-$downloadPage = Invoke-WebRequest -Uri "https://www.cursor.com/api/download?platform=win32-x64-user&releaseTrack=stable" | ConvertFrom-Json
+$downloadPage = Invoke-WebRequest -Uri "https://www.cursor.com/api/download?platform=win32-x64-user&releaseTrack=stable" -UseBasicParsing | ConvertFrom-Json
 $jsonObject = ($downloadPage.downloadUrl)
 
 # Import the UpdateChocolateyPackage function

--- a/Grayjay/updateNew.ps1
+++ b/Grayjay/updateNew.ps1
@@ -17,7 +17,7 @@ try {
     do {
         $versionNumber++
         $mostUpToDateUrl = "https://updater.grayjay.app/Apps/Grayjay.Desktop/${versionNumber}/Grayjay.Desktop-win-x64-v${versionNumber}.zip"
-        $response = Invoke-WebRequest -Uri $mostUpToDateUrl -Method Head -ErrorAction Stop
+        $response = Invoke-WebRequest -Uri $mostUpToDateUrl -UseBasicParsing -Method Head -ErrorAction Stop
         Write-Host "$mostUpToDateUrl is valid and reachable (Status Code: $($response.StatusCode))."
 
 

--- a/LM_Studio/test.ps1
+++ b/LM_Studio/test.ps1
@@ -1,4 +1,4 @@
-$downloadPage = Invoke-WebRequest -Uri "https://lmstudio.ai/download"
+$downloadPage = Invoke-WebRequest -Uri "https://lmstudio.ai/download" -UseBasicParsing
 $downloadUrl = $downloadPage.Links | 
     Where-Object { $_.href -like "*LM-Studio*x64.exe" } | 
     Select-Object -ExpandProperty href

--- a/LM_Studio/updateNew.ps1
+++ b/LM_Studio/updateNew.ps1
@@ -6,7 +6,7 @@ $ParentPath = Split-Path -Parent $ScriptPath
 . (Join-Path $ParentPath 'Chocolatey-Package-Updater.ps1')
 
 # Fetch the download link from the website
-$downloadPage = Invoke-WebRequest -Uri "https://lmstudio.ai"
+$downloadPage = Invoke-WebRequest -Uri "https://lmstudio.ai" -UseBasicParsing
 $downloadLink = ($downloadPage.Links | Where-Object { $_.href -like "*LM-Studio-*-x64.exe" }).href
 Write-Output "Download URL: $downloadLink"
 

--- a/WhisperTyping/updateNew.ps1
+++ b/WhisperTyping/updateNew.ps1
@@ -5,7 +5,7 @@ $ParentPath = Split-Path -Parent $ScriptPath
 # Import the UpdateChocolateyPackage function
 . (Join-Path $ParentPath 'Chocolatey-Package-Updater.ps1')
 
-$downloadPage = Invoke-WebRequest -Uri "https://api.whispertyping.com/update?channel=stable" | ConvertFrom-Json
+$downloadPage = Invoke-WebRequest -Uri "https://api.whispertyping.com/update?channel=stable" -UseBasicParsing | ConvertFrom-Json
 $jsonObject = ($downloadPage.installer)
 
 # Create a hash table to store package information

--- a/Windsurf/updateNew.ps1
+++ b/Windsurf/updateNew.ps1
@@ -6,7 +6,7 @@ $ParentPath = Split-Path -Parent $ScriptPath
 . (Join-Path $ParentPath 'Chocolatey-Package-Updater.ps1')
 
 # Fetch the download link from the website
-$downloadPage = Invoke-WebRequest -Uri "https://windsurf-stable.codeium.com/api/update/win32-x64-user/stable/latesti" | ConvertFrom-Json
+$downloadPage = Invoke-WebRequest -Uri "https://windsurf-stable.codeium.com/api/update/win32-x64-user/stable/latesti" -UseBasicParsing | ConvertFrom-Json
 $jsonObject = ($downloadPage.url)
 
 # Create a hash table to store package information

--- a/scripts/Check-ChocolateyStatus.ps1
+++ b/scripts/Check-ChocolateyStatus.ps1
@@ -21,7 +21,7 @@ if (-not (Test-Path $logDir)) {
 # Write-Host "Checking Chocolatey URL: $url"
 
 try {
-    $response = Invoke-WebRequest -Uri $url -Method Get -TimeoutSec 20 # Added timeout
+    $response = Invoke-WebRequest -Uri $url -UseBasicParsing -Method Get -TimeoutSec 20 # Added timeout
     
     # Check for HTTP status codes that indicate the page exists
     # 200 (OK), 201 (Created), 202 (Accepted) are good indicators.

--- a/scripts/fullUpdateScript.ps1
+++ b/scripts/fullUpdateScript.ps1
@@ -694,7 +694,7 @@ function UpdateChocolateyPackage {
         }
         else {
             Write-Debug "Using Invoke-WebRequest to download the file."
-            Invoke-WebRequest -Uri $url -OutFile $tempPath
+            Invoke-WebRequest -Uri $url -OutFile $tempPath -UseBasicParsing
         }
 
         # Verify the file exists
@@ -823,7 +823,7 @@ function UpdateChocolateyPackage {
             Write-Debug "Scraping URL: $ScrapeUrl"
             Write-Debug "Scrape pattern: $ScrapePattern"
 
-            $page = Invoke-WebRequest -Uri $ScrapeUrl
+            $page = Invoke-WebRequest -Uri $ScrapeUrl -UseBasicParsing
             if ($page.Content -match $ScrapePattern -and $matches[0] -match '^\d+(\.\d+){1,3}$') {
                 Write-Output "Scraped version: $($matches[0])"
                 $ForceVersionNumber = $matches[0]
@@ -838,7 +838,7 @@ function UpdateChocolateyPackage {
             Write-Debug "Scraping URL: $ScrapeUrl"
             Write-Debug "Download URL scrape pattern: $DownloadUrlScrapePattern"
 
-            $page = Invoke-WebRequest -Uri $ScrapeUrl
+            $page = Invoke-WebRequest -Uri $ScrapeUrl -UseBasicParsing
             if ($page.Content -match $DownloadUrlScrapePattern) {
                 Write-Output "Scraped download URL: $($matches[0])"
                 $FileUrl = $matches[0]
@@ -852,7 +852,7 @@ function UpdateChocolateyPackage {
                 Write-Debug "Scraping URL: $ScrapeUrl"
                 Write-Debug "Download URL scrape pattern (64-bit): $DownloadUrlScrapePattern"
 
-                $page = Invoke-WebRequest -Uri $ScrapeUrl
+                $page = Invoke-WebRequest -Uri $ScrapeUrl -UseBasicParsing
                 if ($page.Content -match $DownloadUrlScrapePattern64) {
                     Write-Output "Scraped 64-bit download URL: $($matches[0])"
                     $FileUrl64 = $matches[0]

--- a/vexcode/test.ps1
+++ b/vexcode/test.ps1
@@ -1,5 +1,5 @@
 $url = "https://link.vex.com/vexcode-v5blocks-windows"
-$response = Invoke-WebRequest -Uri $url -MaximumRedirection 0 -ErrorAction Ignore
+$response = Invoke-WebRequest -Uri $url -UseBasicParsing -MaximumRedirection 0 -ErrorAction Ignore
 if ($response.StatusCode -ge 300 -and $response.StatusCode -lt 400) {
     $redirectUrl = $response.Headers["Location"]
     Write-Output $redirectUrl


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR adds the `-UseBasicParsing` parameter to all instances of `Invoke-WebRequest` across the entire repository. This parameter instructs PowerShell to use a basic, internal parser instead of spinning up the underlying Windows Internet Explorer DOM parser.

⚠️ **Risk:** The potential impact if left unfixed
In Windows PowerShell (up to version 5.1), running `Invoke-WebRequest` without `-UseBasicParsing` invokes the Internet Explorer (IE) MSHTML DOM engine in the background to parse the content. If malicious or extremely large payloads are fetched, it can lead to massive memory usage spikes and significant execution delays, causing a Denial of Service (DoS) and memory leak scenario on the agent running the script. Additionally, if the system is configured without the IE first-run setup, it could completely block script execution.

🛡️ **Solution:** How the fix addresses the vulnerability
By explicitly appending `-UseBasicParsing`, the script completely bypasses the reliance on the IE engine. It processes the response as raw text securely, eliminating the risk of HTML parsing vulnerabilities, significantly reducing overhead/memory footprint, and ensuring consistent execution across different environments. This maintains backward compatibility and works seamlessly in modern environments (where this flag is default/ignored).

---
*PR created automatically by Jules for task [393602686703243729](https://jules.google.com/task/393602686703243729) started by @targed*